### PR TITLE
fix: Error objects losing custom properties

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fifo/convee",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "exports": "./src/index.ts",
   "imports": {
     "std/": "https://deno.land/std@0.224.0/"
@@ -15,7 +15,8 @@
       "src/testdata/",
       "src/fixtures/**/*.ts",
       "**/*.test.ts",
-      "src/index-test.ts"
+      "src/index-test.ts",
+      "src/test/utils/examples/**/*.ts"
     ],
     "rules": {
       "tags": ["recommended"],

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fifo/convee",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "exports": "./src/index.ts",
   "imports": {
     "std/": "https://deno.land/std@0.224.0/"

--- a/src/belt-plugin/index.ts
+++ b/src/belt-plugin/index.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file no-explicit-any
 import { Modifier, Transformer } from "../core/types.ts";
 import { ConveeError } from "../error/index.ts";
 import { RequireAtLeastOne } from "../utils/types/require-at-least-one.ts";

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -6,15 +6,13 @@ export class ConveeError<ErrorT extends Error>
   implements IConveeError<ErrorT>
 {
   public engineStack: EngineMetadata[];
-  public sourceError: ErrorT;
 
   constructor(args: IConveeErrorPayload<ErrorT>) {
     super(args.message);
 
     // Restore prototype chain (for instanceof checks to work properly)
-    Object.setPrototypeOf(this, new.target.prototype);
+    Object.assign(this, args.error); // Copy custom properties
 
-    this.sourceError = args.error;
     this.engineStack = [];
   }
 

--- a/src/error/types.ts
+++ b/src/error/types.ts
@@ -2,7 +2,6 @@ import { EngineMetadata } from "../core/types.ts";
 
 export interface IConveeError<ErrorT extends Error> extends Error {
   engineStack: EngineMetadata[];
-  sourceError: ErrorT;
 
   enrichConveeStack: (metadata: EngineMetadata) => IConveeError<ErrorT>;
 }

--- a/src/error/util.ts
+++ b/src/error/util.ts
@@ -15,6 +15,6 @@ export const isConveeError = <ErrorT extends Error>(
   return (error as ConveeError<ErrorT>).engineStack !== undefined;
 };
 
-export const isError = (value: any): value is Error => {
+export const isError = (value: unknown): value is Error => {
   return value instanceof Error;
 };

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file no-explicit-any
 import { BeltPlugin } from "../belt-plugin/types.ts";
 import { CoreProcessType } from "../core/types.ts";
 import {
@@ -10,7 +11,6 @@ import {
   PipelineSteps,
 } from "./types.ts";
 import { ProcessEngine } from "../process-engine/index.ts";
-import { ProcessEngineOptions } from "../process-engine/types.ts";
 import { RunOptions } from "../index.ts";
 
 function createPipeline<
@@ -50,7 +50,7 @@ function createPipeline<
   ): Promise<LastOutput<Steps>> {
     const currentSteps = customizedSteps ? customizedSteps : steps;
 
-    let result: any = input;
+    let result: unknown = input;
     for (const step of currentSteps) {
       if (typeof step === "function") {
         // For simple functions (modifier or transformer), simply call the function.
@@ -69,7 +69,7 @@ function createPipeline<
         throw new Error("Invalid pipeline step");
       }
     }
-    return await result; //as LastOutput<Steps>;
+    return (await result) as LastOutput<Steps>;
   }
 
   function wrapRunWithCustomSteps() {


### PR DESCRIPTION
This pull request makes a minor update to the `deno.json` configuration file, specifically bumping the package version from `0.4.3` to `0.5.0`. This is likely in preparation for a new release and does not include any other functional changes.
This pull request updates the `@fifo/convee` package to version 0.5.1 and introduces several improvements focused on type safety and error handling. The most significant changes include removing the `sourceError` property from the `ConveeError` class and related interfaces, improving type usage in pipeline and error utilities, and expanding test file inclusion.

**Error handling improvements:**

* Removed the `sourceError` property from the `ConveeError` class and `IConveeError` interface, and now copies custom properties from the error object directly onto the `ConveeError` instance for better error encapsulation (`src/error/index.ts`, `src/error/types.ts`). [[1]](diffhunk://#diff-aca4f28f6db1199630e862727b0556d980b58cfe5be387ed21427125354c5f9fL9-L17) [[2]](diffhunk://#diff-78b392e7d2f197e073c9071fd7f13f3f69191d6b181328f89659e2d155954d0cL5)
* Updated the `isError` utility function to use `unknown` instead of `any` for its input parameter, improving type safety (`src/error/util.ts`).

**Type safety and code quality:**

* Switched pipeline input and result types from `any` to `unknown` for safer type handling in `createPipeline` and added lint ignore comments for explicit `any` usage (`src/pipeline/index.ts`). [[1]](diffhunk://#diff-47ae59677f4d836da757fe5e297b884547af55a95e1ab356f0775f5d5d4c35d0R1) [[2]](diffhunk://#diff-47ae59677f4d836da757fe5e297b884547af55a95e1ab356f0775f5d5d4c35d0L53-R53) [[3]](diffhunk://#diff-47ae59677f4d836da757fe5e297b884547af55a95e1ab356f0775f5d5d4c35d0L72-R72)
* Added lint ignore comments for explicit `any` usage in `src/belt-plugin/index.ts` to suppress lint warnings (`src/belt-plugin/index.ts`).

**Configuration and testing:**

* Updated package version in `deno.json` to 0.5.1 (`deno.json`).
* Expanded the test file inclusion glob pattern to cover additional example files for testing (`deno.json`).