### PR TITLE
fix : remove async ambiguity and enhance plugin system with synchrono…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fifo/convee",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "exports": "./src/index.ts",
   "imports": {
     "std/": "https://deno.land/std@0.224.0/",

--- a/src/belt-plugin/index.ts
+++ b/src/belt-plugin/index.ts
@@ -1,6 +1,7 @@
 // deno-lint-ignore-file no-explicit-any
-import { Modifier, Transformer } from "../core/types.ts";
+import { Modifier, Transformer, TransformerSync } from "../core/types.ts";
 import { ConveeError } from "../error/index.ts";
+import { ModifierAsync, ModifierSync } from "../index.ts";
 import { RequireAtLeastOne } from "../utils/types/require-at-least-one.ts";
 import {
   BeltPlugin,
@@ -24,16 +25,23 @@ type ComposeBeltPlugin<I, O, E extends Error, M> = PluginBase &
     ? { processError: Transformer<ConveeError<E>, ConveeError<E> | O> }
     : Empty);
 
-type ExtractInput<M> = M extends { processInput: Modifier<infer I> }
+type ExtractInput<M> = M extends { processInput: ModifierSync<infer I> }
+  ? I
+  : M extends { processInput: ModifierAsync<infer I> }
   ? I
   : never;
-type ExtractOutput<M> = M extends { processOutput: Modifier<infer O> }
+type ExtractOutput<M> = M extends { processOutput: ModifierSync<infer O> }
+  ? O
+  : M extends { processOutput: ModifierAsync<infer O> }
   ? O
   : never;
 type ExtractError<M> = M extends {
-  processError: Transformer<ConveeError<infer E>, ConveeError<infer E> | any>;
+  processError: TransformerSync<
+    ConveeError<infer E>,
+    ConveeError<infer E> | any
+  >;
 }
-  ? E
+  ? ConveeError<E>
   : Error;
 
 function create<

--- a/src/belt-plugin/types.ts
+++ b/src/belt-plugin/types.ts
@@ -44,7 +44,6 @@ export type BeltPlugin<Input, Output, ErrorT extends Error> = (PluginBase &
         >;
       }>
   );
-
 // export type BeltPlugin<Input, Output, ErrorT extends Error> = PluginBase &
 //   RequireAtLeastOne<{
 //     processInput?: Modifier<Input>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -6,19 +6,29 @@ export enum CoreProcessType {
   PIPELINE = "PIPELINE",
 }
 
-export type Modifier<item> = {
-  (item: item, metadataHelper?: MetadataHelper): Promise<item> | item;
-};
-// | {
-//     (item: item, metadataHelper?: MetadataHelper): item;
-//   };
+export type Modifier<ItemType> =
+  | ModifierSync<ItemType>
+  | ModifierAsync<ItemType>;
 
-export type Transformer<input, output> = {
-  (item: input, metadataHelper?: MetadataHelper): Promise<output> | output;
+export type ModifierSync<ItemType> = {
+  (item: ItemType, metadataHelper?: MetadataHelper): ItemType;
 };
-// | {
-//     (item: input, metadataHelper?: MetadataHelper): output;
-//   };
+
+export type ModifierAsync<ItemType> = {
+  (item: ItemType, metadataHelper?: MetadataHelper): Promise<ItemType>;
+};
+
+export type Transformer<Input, Output> =
+  | TransformerSync<Input, Output>
+  | TransformerAsync<Input, Output>;
+
+export type TransformerAsync<Input, Output> = {
+  (item: Input, metadataHelper?: MetadataHelper): Promise<Output>;
+};
+
+export type TransformerSync<Input, Output> = {
+  (item: Input, metadataHelper?: MetadataHelper): Output;
+};
 
 export type EngineMetadata = {
   source: string;

--- a/src/pipeline/index.unit.test.ts
+++ b/src/pipeline/index.unit.test.ts
@@ -12,7 +12,7 @@ const stringToNumberPlusOneTransformer: Transformer<string, number> = async (
 };
 
 const doubleNumberModifier: Modifier<number> = async (item: number) => {
-  return item * 2;
+  return Promise.resolve(item * 2);
 };
 
 const numberToStringEngine = ProcessEngine.create((n: number) => n.toString(), {
@@ -102,7 +102,7 @@ Deno.test("Pipeline execution with outer belt plugins", async () => {
 
   const subtractThreePlugin = {
     name: "subtractThree",
-    processOutput: (item: number) => item - 3,
+    processOutput: async (item: number) => Promise.resolve(item - 3),
   };
 
   // Create a pipeline with a single modifier.

--- a/src/process-engine/index.ts
+++ b/src/process-engine/index.ts
@@ -5,17 +5,21 @@ import {
   BeltPluginInput,
   BeltPluginOutput,
 } from "../belt-plugin/types.ts";
-import { CoreProcessType } from "../core/types.ts";
+import { CoreProcessType, Transformer } from "../core/types.ts";
 import { ConveeError } from "../error/index.ts";
 import { isConveeCapable, isError, makeConveeCapable } from "../error/util.ts";
-import { ProcessEngineMetadata, ProcessEngineOptions } from "../index.ts";
+import {
+  Modifier,
+  ProcessEngineMetadata,
+  ProcessEngineOptions,
+} from "../index.ts";
 import { MetadataHelper } from "../metadata/collector/index.ts";
 import { MetadataCollected } from "../metadata/collector/types.ts";
 import { Unwrap } from "../utils/types/unwrap.ts";
 import { RunOptions, ProcessEngine as IProcessEngine } from "./types.ts";
 
 function CreateProcess<I, O, E extends Error>(
-  process: (args: I, metadataHelper?: MetadataHelper) => O,
+  process: Modifier<I | O> | Transformer<I, O>, //(args: I, metadataHelper?: MetadataHelper) => O,
   options?: ProcessEngineOptions<I, O, E>
 ): IProcessEngine<I, Unwrap<O>, E> {
   const processType = CoreProcessType.PROCESS_ENGINE;
@@ -50,7 +54,7 @@ function CreateProcess<I, O, E extends Error>(
   engine.run = wrapProcessFn(process);
 
   function wrapProcessFn(
-    process: (input: I, metadataHelper?: MetadataHelper) => O
+    process: Modifier<I | O> | Transformer<I, O> //(input: I, metadataHelper?: MetadataHelper) => O
   ): (input: I, options?: RunOptions<I, O, E>) => Promise<O> {
     return async function (
       this: typeof engine,

--- a/src/test/utils/examples/plugin/input-belt/double-number.ts
+++ b/src/test/utils/examples/plugin/input-belt/double-number.ts
@@ -14,6 +14,6 @@ export const doubleNumberInputPlugin: BeltPluginInput<number> = Plugin.create({
       );
     }
 
-    return n * 2;
+    return Promise.resolve(n * 2);
   },
 });

--- a/src/test/utils/examples/plugin/input-belt/invert-sign.ts
+++ b/src/test/utils/examples/plugin/input-belt/invert-sign.ts
@@ -4,10 +4,10 @@ import { MetadataHelper } from "../../../../../metadata/collector/index.ts";
 
 export const invertSignInputPlugin: BeltPluginInput<{ a: number; b: number }> =
   Plugin.create({
-    processInput: async (
+    processInput: (
       item: { a: number; b: number },
       metadataHelper?: MetadataHelper
-    ): Promise<{ a: number; b: number }> => {
+    ): { a: number; b: number } => {
       if (metadataHelper) {
         metadataHelper.add(
           "InvertSignInputPlugin",


### PR DESCRIPTION
…us and asynchronous modifiers and transformers
This pull request refactors the pipeline and plugin type system to clearly distinguish between synchronous and asynchronous modifiers and transformers. The changes improve type safety and clarity throughout the codebase, ensuring that pipeline steps and plugins are correctly typed and handled. Several test and example plugins are updated to match the new type definitions.

**Type System Refactor:**

* Added explicit `ModifierSync`, `ModifierAsync`, `TransformerSync`, and `TransformerAsync` types to `src/core/types.ts`, replacing ambiguous union types for modifiers and transformers.
* Updated pipeline and plugin type definitions in `src/belt-plugin/index.ts` and `src/pipeline/types.ts` to use the new sync/async modifier and transformer types, and adjusted type extraction utilities accordingly. [[1]](diffhunk://#diff-4d7102b515651d471440d004731a925df2dafb27a9ecc9af10de650580e81aa2L2-R4) [[2]](diffhunk://#diff-4d7102b515651d471440d004731a925df2dafb27a9ecc9af10de650580e81aa2L27-R44) [[3]](diffhunk://#diff-f52c6e493c654f778128261bab6516b6fdfa0771afb70c4d987ae1484d0e966fL3-R9) [[4]](diffhunk://#diff-f52c6e493c654f778128261bab6516b6fdfa0771afb70c4d987ae1484d0e966fL49-R68)
* Refined `FirstInput` and `LastOutput` type utilities to unwrap promise types for improved type inference in pipelines.

**Pipeline and Process Engine Updates:**

* Updated `createPipeline` in `src/pipeline/index.ts` to use the new types, improved plugin typing, and ensured proper casting and unwrapping of results. [[1]](diffhunk://#diff-47ae59677f4d836da757fe5e297b884547af55a95e1ab356f0775f5d5d4c35d0L14-R15) [[2]](diffhunk://#diff-47ae59677f4d836da757fe5e297b884547af55a95e1ab356f0775f5d5d4c35d0L26-R40) [[3]](diffhunk://#diff-47ae59677f4d836da757fe5e297b884547af55a95e1ab356f0775f5d5d4c35d0L72-R86) [[4]](diffhunk://#diff-47ae59677f4d836da757fe5e297b884547af55a95e1ab356f0775f5d5d4c35d0L90-R96)
* Refactored `ProcessEngine.create` in `src/process-engine/index.ts` to accept the new modifier and transformer types, ensuring consistent handling of sync/async processing. [[1]](diffhunk://#diff-698bb4ac4512765bf17e2ee9c1331098618b9da625bb07d0b981997fc83e72fbL8-R22) [[2]](diffhunk://#diff-698bb4ac4512765bf17e2ee9c1331098618b9da625bb07d0b981997fc83e72fbL53-R57)

**Test and Example Plugin Updates:**

* Updated test modifiers and plugins to use explicit async or sync signatures as required by the new types, ensuring compatibility with the refactored pipeline. [[1]](diffhunk://#diff-cc45834c4a6531eda1914c381e6b033bd8ba952c3f119b58b83119c6377893e9L15-R15) [[2]](diffhunk://#diff-cc45834c4a6531eda1914c381e6b033bd8ba952c3f119b58b83119c6377893e9L105-R105) [[3]](diffhunk://#diff-33437ba19066dce8de72549ad856ef03ffe90fcbc8020ae9753a017bc00ebab3L17-R17) [[4]](diffhunk://#diff-2a052c3b2ed1dd03a7591ead1e6905e54ecc62b743cf905000f1f8dcad8c69c1L7-R10)

**Version Update:**

* Bumped the package version in `deno.json` from `0.6.0` to `0.6.1` to reflect these breaking changes.