### PR TITLE
refactor: update StoreOutputConnector type and improve storeOutput fu…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fifo/convee",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "exports": "./src/index.ts",
   "imports": {
     "std/": "https://deno.land/std@0.224.0/",

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -59,7 +59,7 @@ export type PipelineStep<Input, Output, ErrorT extends Error> =
   | ProcessEngine<Input, Output, ErrorT>;
 
 // StepIO extracts the input/output pair from a PipelineStep.
-type StepIO<T> = T extends ModifierSync<infer U>
+export type StepIO<T> = T extends ModifierSync<infer U>
   ? [U, U]
   : T extends ModifierAsync<infer U>
   ? [U, U]

--- a/src/processes/pipeline-connectors/store-output.ts
+++ b/src/processes/pipeline-connectors/store-output.ts
@@ -1,17 +1,19 @@
-import { Modifier } from "../../core/types.ts";
+// deno-lint-ignore-file no-explicit-any
+import { Modifier, ModifierAsync, ModifierSync } from "../../core/types.ts";
 import { MetadataHelper } from "../../metadata/collector/index.ts";
+import { PipelineStep } from "../../pipeline/types.ts";
 
-export type StoreOutputConnector<PreviousStepOutput> =
-  Modifier<PreviousStepOutput>;
+export type StoreOutputConnector<PreviousStep> =
+  PreviousStep extends PipelineStep<any, infer PreviousStepOutput, any>
+    ? Modifier<PreviousStepOutput>
+    : never;
 
-export const storeOutput = <PreviousStepOutput>(
+export function storeOutput<PreviousStep extends PipelineStep<any, any, any>>(
+  previousStep: PreviousStep,
   key: string
-): StoreOutputConnector<PreviousStepOutput> => {
-  return ((
-    input: PreviousStepOutput,
-    metadataHelper: MetadataHelper
-  ): PreviousStepOutput => {
+): StoreOutputConnector<PreviousStep> {
+  return ((input: unknown, metadataHelper: MetadataHelper) => {
     metadataHelper.add(key, input);
     return input;
-  }) as Modifier<PreviousStepOutput>;
-};
+  }) as StoreOutputConnector<typeof previousStep>;
+}


### PR DESCRIPTION
…nction signature
This pull request introduces improvements to the `storeOutput` connector in the pipeline framework, enhancing type safety and flexibility. The changes update how output from pipeline steps is stored and referenced in metadata, and refactor related tests to use the new approach.

**StoreOutput connector improvements:**

* Refactored `storeOutput` and `StoreOutputConnector` in `store-output.ts` to infer the output type directly from the previous pipeline step, improving type safety and eliminating the need for manual type specification. (`[src/processes/pipeline-connectors/store-output.tsL1-R19](diffhunk://#diff-8d31dc23193d2e9c95bc9e0f1f88af0fc7803046acd2d08537ef648f4f073f1fL1-R19)`)
* Updated usage of `storeOutput` in `index.test.ts` to pass the actual pipeline step and a custom key, enabling more precise metadata tracking for each step. (`[src/processes/pipeline-connectors/index.test.tsR38-R57](diffhunk://#diff-33f7669ee039c7748e88a55677510d60a6db9c57a7557712c791b7f668e745efR38-R57)`)

**Testing and metadata updates:**

* Modified assertions in `index.test.ts` to check metadata using the new custom keys, ensuring the correct outputs are stored for each pipeline step. (`[src/processes/pipeline-connectors/index.test.tsL60-R88](diffhunk://#diff-33f7669ee039c7748e88a55677510d60a6db9c57a7557712c791b7f668e745efL60-R88)`)
* Added new test steps (`numberToObject`, `objToNumber`) to demonstrate storing outputs of different types and verifying their presence in metadata. (`[src/processes/pipeline-connectors/index.test.tsR38-R57](diffhunk://#diff-33f7669ee039c7748e88a55677510d60a6db9c57a7557712c791b7f668e745efR38-R57)`)

**Type system improvements:**

* Exported `StepIO` type from `types.ts` to facilitate type extraction for pipeline steps, supporting the new connector implementation. (`[src/pipeline/types.tsL62-R62](diffhunk://#diff-f52c6e493c654f778128261bab6516b6fdfa0771afb70c4d987ae1484d0e966fL62-R62)`)

**Miscellaneous:**

* Bumped the package version in `deno.json` from `0.7.0` to `0.7.1` to reflect these enhancements. (`[deno.jsonL3-R3](diffhunk://#diff-54337bcff4b919f6b8b4e0b0e51d06fd9124562fde88899be726c24b7e354b7cL3-R3)`)